### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,14 @@
 {
+  "resolutions": {
+      "@discordjs/builders": "1.6.3",
+      "@discordjs/formatters": "0.3.1",
+      "@discordjs/util": "0.3.1",
+      "@discordjs/rest": "1.7.1",
+      "@discordjs/ws": "0.8.3",
+      "@discordjs/collection": "1.5.1"
+  },
   "dependencies": {
-    "discord.js": "^14.7.1",
+    "discord.js": "14.10.2",
     "jsonc-parser": "^3.2.0",
     "node-fetch": ">=2.6.7 <3.0.0"
   }


### PR DESCRIPTION
This fixes dependency issues created by the release of discord.js 14.13.0 because their packages are set to automatically grab the latest version of every dependency. An issue was opened in their repo where they stated their solution is to override the dependencies in the package.json. Furthermore, this would not be an issue if FiveM was using a modern instance of node.js and an issue was opened with them to update node.js, so this work around wouldn't be needed in the future. Please note that there's a breaking change in @discordjs/util 1.0.0 with your script and the script will need to be modified prior to updating to 1.0.0

https://github.com/citizenfx/fivem/issues/2166
workaround
https://github.com/discordjs/discord.js/issues/9792

